### PR TITLE
module.river: fix typo

### DIFF
--- a/k8s_pods/module.river
+++ b/k8s_pods/module.river
@@ -123,10 +123,10 @@ discovery.relabel "metrics_pods" {
 
 prometheus.scrape "metrics_pods" {
 	targets    = discovery.relabel.metrics_pods.output
-	forawrd_to = argument.forward_metrics_to.value
+	forward_to = argument.forward_metrics_to.value
 }
 
 loki.source.kubernetes "pods" {
 	targets    = discovery.relabel.pods.output
-	forawrd_to = argument.forward_logs_to.value
+	forward_to = argument.forward_logs_to.value
 }


### PR DESCRIPTION
I didn't try to run anything with this config yet, but this looks like an obvious typo.