### PR TITLE
k8s_pods/module.river: add app and name labels

### DIFF
--- a/k8s_pods/README.md
+++ b/k8s_pods/README.md
@@ -49,7 +49,7 @@ All telemetry data will have the following labels:
   * A label named `k8s-app`.
   * A label named `app`.
   * A label named `name`.
-  * A combination of the `kubernetes.io/instance` and `kubernetes.io/naem`
+  * A combination of the `kubernetes.io/instance` and `kubernetes.io/name`
     labels, concatenated with a hyphen.
   * The pod controller name.
   * The pod name.

--- a/k8s_pods/README.md
+++ b/k8s_pods/README.md
@@ -56,6 +56,8 @@ All telemetry data will have the following labels:
 * `namespace`: set to `POD_NAMESPACE`.
 * `pod`: set to `POD_NAME`.
 * `container`: set to `POD_CONTAINER_NAME`.
+* `app`: set to the value of the `app` label if present.
+* `name`: set to the value of the `app.kubernetes.io/name` label if present.
 
 Additionally, when collecting metrics, the `instance` label is set to
 `POD_NAME:POD_CONTAINER_NAME:POD_CONTAINER_PORT_NAME`.

--- a/k8s_pods/module.river
+++ b/k8s_pods/module.river
@@ -96,6 +96,17 @@ discovery.relabel "pods" {
 		source_labels = ["__meta_kubernetes_pod_container_name"]
 		target_label  = "container"
 	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_label_app"]
+		target_label = "app"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+		target_label = "name"
+	}
+
 }
 
 discovery.relabel "metrics_pods" {


### PR DESCRIPTION
It seems these labels were also present in the log entries produced by grafana agent operator (from a grafana-agent config):

```
                - regex: (.+)
                  replacement: $1
                  source_labels:
                    - __meta_kubernetes_pod_label_name
                  target_label: name
                - regex: (.+)
                  replacement: $1
                  source_labels:
                    - __meta_kubernetes_pod_label_app
                  target_label: app
```